### PR TITLE
fix null returns in Moon values

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -123,12 +123,12 @@ pub struct Sun {
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "PascalCase")]
 pub struct Moon {
-    pub rise: String,
-    pub epoch_rise: i64,
-    pub set: String,
-    pub epoch_set: i64,
-    pub phase: String,
-    pub age: i32,
+    pub rise: Option<String>,
+    pub epoch_rise: Option<i64>,
+    pub set: Option<String>,
+    pub epoch_set: Option<i64>,
+    pub phase: Option<String>,
+    pub age: Option<i32>,
 }
 
 /// Representation of daily forecast


### PR DESCRIPTION
the accuweather API sometimes sends "null" values in the Moon return.