### PR TITLE
Changes to support String Location Key, and potentially null values in Accuweather responses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "accuweather"
 description = "A library to fetch data from accuweather api"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Gaëtan Duchaussois <gaetan@pignouf.fr>"]
 edition = "2018"
 repository = "https://github.com/gaetronik/accuweather"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,11 +11,9 @@
 //! let client = accuweather::Accuweather::new(api_key, Some(12345), None);
 //! // get next 12 hours of hourly forecasts
 //! let hourly_forecasts = client.get_hourly_forecasts(12);
-//! 
+//!
 //! let daily_forecasts = client.get_daily_forecasts(5);
 //! let conditions = client.get_current_conditions();
-
-
 
 extern crate reqwest;
 #[macro_use]
@@ -54,7 +52,7 @@ impl error::Error for AccuweatherInvalidParameterError {
 pub struct Accuweather {
     pub client: Client,
     pub api_key: String,
-    pub location: Option<i32>,
+    pub location: Option<String>,
     pub language: String,
     base_url: String,
 }
@@ -73,7 +71,7 @@ impl Accuweather {
     /// }
     /// ```
 
-    pub fn new(api_key: String, location: Option<i32>, language: Option<String>) -> Self {
+    pub fn new(api_key: String, location: Option<String>, language: Option<String>) -> Self {
         #[cfg(not(test))]
         let url = "http://dataservice.accuweather.com";
         #[cfg(test)]
@@ -101,7 +99,7 @@ impl Accuweather {
     ///  client.set_location(Some(1234));
     ///  assert_eq!(client.location, Some(1234));
     /// ```
-    pub fn set_location(&mut self, location: Option<i32>) {
+    pub fn set_location(&mut self, location: Option<String>) {
         self.location = location;
     }
 
@@ -133,7 +131,7 @@ impl Accuweather {
             "{}/forecasts/v1/hourly/{}hour/{:?}",
             self.base_url,
             period,
-            self.location.unwrap()
+            self.location.as_ref().unwrap()
         );
         let url = Url::parse_with_params(
             &url,
@@ -171,10 +169,10 @@ impl Accuweather {
             _ => return Err(AccuweatherInvalidParameterError.into()),
         };
         let url = format!(
-            "{}/forecasts/v1/daily/{}day/{:?}",
+            "{}/forecasts/v1/daily/{}day/{}",
             self.base_url,
             period,
-            self.location.unwrap()
+            self.location.as_ref().unwrap()
         );
         let url = Url::parse_with_params(
             &url,
@@ -203,9 +201,9 @@ impl Accuweather {
 
     pub fn get_current_conditions(&self) -> Result<Vec<CurrentCondition>> {
         let url = format!(
-            "{}/currentconditions/v1/{:?}",
+            "{}/currentconditions/v1/{}",
             self.base_url,
-            self.location.unwrap()
+            self.location.as_ref().unwrap()
         );
         let url = Url::parse_with_params(
             &url,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,6 +183,7 @@ impl Accuweather {
                 ("language", self.language.clone()),
             ],
         )?;
+        // println!("{:?}", url);
         match self.client.get(url).send()?.error_for_status()?.json() {
             Ok(x) => Ok(x),
             Err(x) => Err(x.into()),

--- a/src/types.rs
+++ b/src/types.rs
@@ -163,10 +163,10 @@ pub struct Headline {
     pub effective_epoch_date: i64,
     pub severity: i32,
     pub text: String,
-    pub category: String,
-    pub end_date: String,
-    pub end_epoch_date: i64,
-    pub mobile_link: String,
+    pub category: Option<String>,
+    pub end_date: Option<String>,
+    pub end_epoch_date: Option<i64>,
+    pub mobile_link: Option<String>,
     pub link: String,
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -40,8 +40,10 @@ pub struct AirAndPollen {
     pub name: String,
     pub value: i32,
     pub category: String,
+    #[allow(dead_code)]
     category_value: i32,
     #[serde(default = "air_pollen_default_type")]
+    #[allow(dead_code)]
     r#type: String,
 }
 
@@ -66,6 +68,7 @@ pub struct Wind {
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "PascalCase")]
 pub struct DailyWindGust {
+    #[allow(dead_code)]
     speed: AccuweatherMeasurement,
 }
 
@@ -113,21 +116,21 @@ pub struct DegreeDaySummary {
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "PascalCase")]
 pub struct Sun {
-    pub rise: String,
-    pub epoch_rise: i64,
-    pub set: String,
-    pub epoch_set: i64,
+    pub rise: Option<String>,
+    pub epoch_rise: Option<i64>,
+    pub set: Option<String>,
+    pub epoch_set: Option<i64>,
 }
 
 /// Representation of Moon information in daily forecast api.
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "PascalCase")]
 pub struct Moon {
-    pub rise: String,
-    pub epoch_rise: i64,
-    pub set: String,
-    pub epoch_set: i64,
-    pub phase: String,
+    pub rise: Option<String>,
+    pub epoch_rise: Option<i64>,
+    pub set: Option<String>,
+    pub epoch_set: Option<i64>,
+    pub phase: Option<String>,
     pub age: i32,
 }
 


### PR DESCRIPTION

When passing in a zip code to the location API, it may return a string and not a simple integer. Updated the code to use Option<String> instead of Option<i32> for this purpose.

Also, Accuweather responses now make some values null, so updated the struct representations to accommodate this. 
